### PR TITLE
Add Breadcrumbs component

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -1,0 +1,20 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 24px;
+  height: 20px;
+
+  margin: 0 -6px;
+  color: var(--tgui--divider);
+}
+
+.chevron {
+  color: var(--tgui--link_color);
+}

--- a/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -12,9 +12,9 @@
   height: 20px;
 
   margin: 0 -6px;
-  color: var(--tgui--divider);
+  color: var(--icon-quaternary);
 }
 
 .chevron {
-  color: var(--tgui--link_color);
+  color: var(--icon-tertiary);
 }

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Breadcrumbs } from 'components';
+
+import { hideArgsControl } from '../../../.storybook/shared/args-manager';
+
+const meta = {
+  title: 'Navigation/Breadcrumbs',
+  component: Breadcrumbs,
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: hideArgsControl(['children'])
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    divider: 'dot'
+  },
+  render: (args) => (
+    <Breadcrumbs {...args}>
+      <Breadcrumbs.Item>First</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Second</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Third</Breadcrumbs.Item>
+    </Breadcrumbs>
+  )
+};
+
+export const Link: Story = {
+  args: {
+    divider: 'dot'
+  },
+  render: (args) => (
+    <Breadcrumbs {...args}>
+      <Breadcrumbs.Item Component="a" href="https://nohello.net/en/" target="_blank" rel="noreferrer">
+        No
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item Component="a" href="https://nohello.net/en/" target="_blank" rel="noreferrer">
+        Hello
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item Component="a" href="https://nohello.net/en/" target="_blank" rel="noreferrer">
+        OK?
+      </Breadcrumbs.Item>
+    </Breadcrumbs>
+  )
+};

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,36 @@
+import { clsx } from 'clsx';
+import { Children, type HTMLAttributes, type ReactNode } from 'react';
+
+import { Icon16Chevron } from '../../icons';
+import styles from './Breadcrumbs.module.scss';
+import { BreadCrumbsItem } from './components/BreadCrumbsItem/BreadCrumbsItem';
+import { IconDot } from './icons/dot';
+import { IconSlash } from './icons/slash';
+
+export interface BreadcrumbsProps extends HTMLAttributes<HTMLDivElement> {
+  divider?: 'dot' | 'slash' | 'chevron'
+  children?: ReactNode
+}
+
+export const Breadcrumbs = ({
+  divider = 'dot',
+  className,
+  children
+}: BreadcrumbsProps): JSX.Element => (
+  <div className={clsx(styles.wrapper, className)}>
+    {Children.map(children, (child, index) => (
+      <>
+        {child}
+        {index !== Children.count(children) - 1 && (
+          <div className={styles.divider}>
+            {divider === 'dot' && <IconDot />}
+            {divider === 'slash' && <IconSlash />}
+            {divider === 'chevron' && <Icon16Chevron className={styles.chevron} />}
+          </div>
+        )}
+      </>
+    ))}
+  </div>
+);
+
+Breadcrumbs.Item = BreadCrumbsItem;

--- a/src/components/Breadcrumbs/components/BreadCrumbsItem/BreadCrumbsItem.module.scss
+++ b/src/components/Breadcrumbs/components/BreadCrumbsItem/BreadCrumbsItem.module.scss
@@ -1,0 +1,19 @@
+.wrapper {
+  cursor: pointer;
+  padding: 8px 10px;
+  border-radius: 8px;
+
+  text-decoration: none;
+  transition: opacity .15s ease-out;
+  color: var(--tgui--hint_color);
+}
+
+.wrapper:active {
+  opacity: .5;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .wrapper:hover {
+    background: var(--tgui--tertiary_bg_color);
+  }
+}

--- a/src/components/Breadcrumbs/components/BreadCrumbsItem/BreadCrumbsItem.module.scss
+++ b/src/components/Breadcrumbs/components/BreadCrumbsItem/BreadCrumbsItem.module.scss
@@ -5,7 +5,7 @@
 
   text-decoration: none;
   transition: opacity .15s ease-out;
-  color: var(--tgui--hint_color);
+  color: var(--text-secondary);
 }
 
 .wrapper:active {
@@ -14,6 +14,6 @@
 
 @media (hover: hover) and (pointer: fine) {
   .wrapper:hover {
-    background: var(--tgui--tertiary_bg_color);
+    background: var(--states-background-hovered-neutral-fade);
   }
 }

--- a/src/components/Breadcrumbs/components/BreadCrumbsItem/BreadCrumbsItem.tsx
+++ b/src/components/Breadcrumbs/components/BreadCrumbsItem/BreadCrumbsItem.tsx
@@ -1,0 +1,20 @@
+import { clsx } from 'clsx';
+import { type AllHTMLAttributes, type ElementType } from 'react';
+
+import { Typography } from '../../../../Typography';
+import styles from './BreadCrumbsItem.module.scss';
+
+export interface BreadCrumbsItemProps extends AllHTMLAttributes<HTMLElement> {
+  Component?: ElementType
+}
+
+export const BreadCrumbsItem = ({
+  Component = 'div',
+  className,
+  children,
+  ...restProps
+}: BreadCrumbsItemProps): JSX.Element => (
+  <Component className={clsx(styles.wrapper, className)} {...restProps}>
+    <Typography.Label variant="medium-strong">{children}</Typography.Label>
+  </Component>
+);

--- a/src/components/Breadcrumbs/icons/dot.tsx
+++ b/src/components/Breadcrumbs/icons/dot.tsx
@@ -1,0 +1,7 @@
+import { type SVGProps } from 'react';
+
+export const IconDot = (props: SVGProps<SVGSVGElement>): JSX.Element => (
+  <svg width="21" height="20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <circle cx="10.5" cy="10" r="2" fill="currentColor" />
+  </svg>
+);

--- a/src/components/Breadcrumbs/icons/slash.tsx
+++ b/src/components/Breadcrumbs/icons/slash.tsx
@@ -1,0 +1,7 @@
+import { type SVGProps } from 'react';
+
+export const IconSlash = (props: SVGProps<SVGSVGElement>): JSX.Element => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M13 5L8 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);

--- a/src/components/Breadcrumbs/index.ts
+++ b/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { Breadcrumbs, type BreadcrumbsProps } from './Breadcrumbs';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Avatar';
+export * from './Breadcrumbs';
 export * from './Button';
 export * from './CellAction';
 export * from './CellHeader';


### PR DESCRIPTION
## Summary
- implement `Breadcrumbs` compound component with divider options
- add subcomponent `BreadCrumbsItem`
- ship dedicated icons for dividers
- expose Breadcrumbs from components index
- document usage with Storybook stories

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a4bf65a8c832e9487df7c4c80fe72